### PR TITLE
fix: add test case and modify docs

### DIFF
--- a/11_ReentrancyGuards/ReentrancyGuards.T.sol
+++ b/11_ReentrancyGuards/ReentrancyGuards.T.sol
@@ -3,23 +3,63 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import "./ReentrancyGuards.sol";
 
-contract ReentrancyGuardsTest is Test{
-    ReentrancyGuardsBool reentrancyGuardsBool;
-    ReentrancyGuardsUint01 reentrancyGuardsUint01;
-    ReentrancyGuardsUint12 reentrancyGuardsUint12;
+contract ReentrancyGuardsTest is Test {
+
+    SimpleCase simpleCase;
+    address owner;
 
     function setUp() public {
+        simpleCase = new SimpleCase();
+        // generate test user
+        owner = vm.addr(1);
+        // add some ether
+        vm.deal(owner, 2 ether);
+        vm.prank(owner);
+        simpleCase.deposit{value: 1 ether}();
     }
 
     function testDeployReentrancyGuardsBool() public {
-        reentrancyGuardsBool = new ReentrancyGuardsBool();
+        vm.prank(owner);
+        simpleCase.withdrawBool();
     }
 
     function testDeployReentrancyGuardsUint01() public {
-        reentrancyGuardsUint01 = new ReentrancyGuardsUint01();
+        vm.prank(owner);
+        simpleCase.withdraw01();
     }
 
     function testDeployReentrancyGuardsUint12() public {
-        reentrancyGuardsUint12 = new ReentrancyGuardsUint12();
+        vm.prank(owner);
+        simpleCase.withdraw12();
+    }
+}
+
+contract SimpleCase is ReentrancyGuardsBool, ReentrancyGuardsUint01, ReentrancyGuardsUint12{
+    
+    mapping(address => uint256) private balance;
+
+    function deposit() external payable {
+        balance[msg.sender] = balance[msg.sender] + msg.value;
+    }
+
+    function withdrawBool() external nonReentrantBool {
+        _withdraw();
+    }
+
+    function withdraw01() external nonReentrant01 {
+        _withdraw();
+    }
+
+    function withdraw12() external nonReentrant12 {
+        _withdraw();
+    }
+
+    function _withdraw() private {
+        uint256 amount = balance[msg.sender];
+        require(amount > 0);
+
+        balance[msg.sender] = 0;
+        (bool suceess, ) = address(msg.sender).call{value: amount}("");
+        require(suceess, "withdraw failed to sender");
     }
 }

--- a/11_ReentrancyGuards/ReentrancyGuards.sol
+++ b/11_ReentrancyGuards/ReentrancyGuards.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
  
 contract ReentrancyGuardsBool{
     bool private locked  = false;
-    modifier nonReentrant(){
+    modifier nonReentrantBool(){
         require(locked == false,"REENTRANCY");
         locked = true;
         _;
@@ -14,7 +14,7 @@ contract ReentrancyGuardsBool{
 
 contract ReentrancyGuardsUint01{
     uint256 private locked = 0;
-    modifier nonReentrant(){
+    modifier nonReentrant01(){
         require(locked == 0,"REENTRANCY");
         locked = 1;
         _;
@@ -25,7 +25,7 @@ contract ReentrancyGuardsUint01{
 
 contract ReentrancyGuardsUint12{
     uint256 private locked = 1;
-    modifier nonReentrant(){
+    modifier nonReentrant12(){
         require(locked == 1,"REENTRANCY");
         locked = 2;
         _;

--- a/11_ReentrancyGuards/readme.md
+++ b/11_ReentrancyGuards/readme.md
@@ -46,7 +46,6 @@ contract ReentrancyGuardsUint12{
         locked = 1;
     }
 }
-
 ```
 
 以下是测试后的情况说明，gas 优化建议如下：
@@ -58,11 +57,11 @@ contract ReentrancyGuardsUint12{
 
 因为一般重入保护函数是会被多次调用的，所以建议使用Uint12这种方式。
 
-| 重入保护 | gas 消耗  | 节省        | 结果    |
-| -------- | -------- | ----------- | ------- |
-| Bool     | 69395    |             |         |
-| Uint01   | 69354    |             |         |
-| Uint12   | 89259    |             | ✅ 建议 |
+| 重入保护 | gas 消耗 | 节省        | 结果   |
+| -------- | -------- | ----------- | ------ |
+| Bool     | 27757    |             |        |
+| Uint01   | 27604    | 153(≈0.6%)  |        |
+| Uint12d  | 13908    | 13849(≈50%) | ✅ 建议 |
 
 参考资料：
 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.8.2/contracts/security/ReentrancyGuard.sol


### PR DESCRIPTION
原来的ReentrancyGuards测试用例中，只是把三种modifier 函数对应的合约实例化，并没有真正用到，而且gas消耗也和理论不对应。所以添加了测试合约，再分别测试三种modifier的gas消耗。最后再修改对应的文档，得出的结论和理论一致。